### PR TITLE
Update Electron to 0.36.1 and Fix the User-Agent Defines

### DIFF
--- a/main.js
+++ b/main.js
@@ -35,6 +35,13 @@ if (shouldQuit) {
 }
 
 app.on('ready', function() {
+  // fake user agent as Chrome 41.0.2228.0
+  var _session = require('electron').session.defaultSession;
+  _session.webRequest.onBeforeSendHeaders((details, callback) => {
+    details.requestHeaders['User-Agent'] = 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36';
+    callback({ cancel: false, requestHeaders: details.requestHeaders });
+  });
+
   // Create the browser window.
   mainWindow = new BrowserWindow({
     width: 1200,
@@ -46,14 +53,11 @@ app.on('ready', function() {
     plugin:true,
     'web-preferences': {
         plugins: true
+    },
+    webPreferences: {
+        plugins: true,
+        session: _session
     }
-  });
-
-  // fake user agent as Chrome 41.0.2228.0
-  var session = mainWindow.webContents.session
-  session.defaultSession.webRequest.onBeforeSendHeaders((details, callback) => {
-    details.requestHeaders['User-Agent'] = 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36';
-    callback({ cancel: false, requestHeaders: details.requestHeaders });
   });
 
   // and load the index.html of the app.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
   },
   "homepage": "https://github.com/atom/electron-quick-start#readme",
   "devDependencies": {
-    "electron-prebuilt": "^0.35.0"
+    "electron-prebuilt": "^0.36.1"
   }
 }


### PR DESCRIPTION
This will update Electron to ^0.36.1 (it went to 0.36.9 in my case), to support the userAgent feature mentioned at Issue #1 
[Source](http://stackoverflow.com/questions/35672602/how-to-set-electron-useragent#comment59099422_35672988)
Will also fix the code to support the user-agent change
