### PR TITLE
Updated dependencies and fixed pause/play button

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@ for Linux.
 
 ![Screenshot](https://raw.githubusercontent.com/Bunkerbewohner/tidal-music-linux/master/screenshot.png)
 
-## Requirements 
+## Requirements
 
 For music playback to work you need the [PepperFlashPlayer plugin](https://wiki.debian.org/PepperFlashPlayer).
 
-On Ubuntu you can install `pepperflashplugin-nonfree` (then run `sudo update-pepperflashplugin-nonfree --install`) which will copy the library to `/usr/lib/pepperflashplugin-nonfree/libpepflashplayer.so` - this path is hardcoded into the application right now. You can change it in main.js by changing the variable `pepperFlashPluginPath`.
+On Ubuntu you can install Flash through [Canonical
+Partners](https://wiki.ubuntu.com/Chromium/Getting-Partner-Flash). Once
+installed, verify the path by opening Chromium and going to [chrome://plugins](chrome://plugins). Click the `details` button on the top right and check that the **Adobe Flash Player** `Location` path is `/usr/lib/adobe-flashplugin/libpepflashplayer.so`. If not then set the `pepperFlashPluginPath` variable in `main.js` to the value reported by Chromium.
 
 
 ## To Use

--- a/index.html
+++ b/index.html
@@ -25,8 +25,14 @@
           case "MediaPlayPause":
             var playBtn = doc.querySelector("button.js-play")
             var pauseBtn = doc.querySelector("button.js-pause")
-            if (pauseBtn.style.display == "none") playBtn.click()
-            else pauseBtn.click()
+            var playPauseContainer= doc.querySelector(".play-controls__main-button")
+            if (playPauseContainer.className.indexOf("playing") == -1) {
+              playBtn.click()
+            }
+            else
+            {
+              pauseBtn.click()
+            }
             break;
 
           case "MediaNextTrack":

--- a/main.js
+++ b/main.js
@@ -1,16 +1,14 @@
-var app = require('app');  // Module to control application life.
-var BrowserWindow = require('browser-window');  // Module to create native browser window.
-var globalShortcut = require('global-shortcut');
-
-// Report crashes to our server.
-require('crash-reporter').start();
+var electron = require('electron');
+var app = electron.app;  // Module to control application life.
+var BrowserWindow = electron.BrowserWindow;  // Module to create native browser window.
+var globalShortcut = electron.globalShortcut;
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
 var mainWindow = null;
 
 // TODO: Determine path to Pepper flash plugin, rather than hardcoding it
-var pepperFlashPluginPath = '/usr/lib/pepperflashplugin-nonfree/libpepflashplayer.so'
+var pepperFlashPluginPath = '/usr/lib/adobe-flashplugin/libpepflashplayer.so'
 app.commandLine.appendSwitch('ppapi-flash-path', pepperFlashPluginPath);
 
 // Quit when all windows are closed.
@@ -44,13 +42,13 @@ app.on('ready', function() {
     autoHideMenuBar: true,
     darkTheme: true,
     plugin:true,
-    'web-preferences': {
+    webPreferences: {
         plugins: true
     }
   });
 
   // and load the index.html of the app.
-  mainWindow.loadURL('file://' + __dirname + '/index.html');
+  mainWindow.loadURL('file://' + __dirname + '/index.html', {userAgent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36"});
 
   // Emitted when the window is closed.
   mainWindow.on('closed', function() {
@@ -61,9 +59,11 @@ app.on('ready', function() {
 
   // handle media keys
   var routeShortcuts = ["MediaPreviousTrack", "MediaNextTrack", "MediaPlayPause", "MediaStop"]
-  routeShortcuts.forEach(shortcut => {    
-    globalShortcut.register(shortcut, function() {
+  routeShortcuts.forEach(shortcut => {
+    if (!globalShortcut.register(shortcut, function() {
       mainWindow.webContents.send("playback-control", shortcut)
-    })
+    })) {
+      console.log("Failed to register shortcut", shortcut, "Is your desktop environment already handling it?");
+    }
   })
 });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "electron-quick-start",
+  "name": "Tidal Music - Linux",
   "version": "1.0.0",
-  "description": "A minimal Electron application",
+  "description": "An electron wrapped client for Tidal",
   "main": "main.js",
   "scripts": {
     "start": "electron main.js"
@@ -23,6 +23,6 @@
   },
   "homepage": "https://github.com/atom/electron-quick-start#readme",
   "devDependencies": {
-    "electron-prebuilt": "^0.35.0"
+    "electron": "^1.0"
   }
 }


### PR DESCRIPTION
Thanks for getting this working, I made some fixes.

Upgraded electron to stable release version.
Upgraded Flash to Canonical Partners as PepperFlash is deprecated and doesn't install on latest Ubuntu.

Fixed pause/play button check as `display:none` doesn't get set anymore

Added a message about `globalShortcuts` not registering because the Desktop Environment may already be listening to them.