### PR TITLE
Playback control fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,50 +5,13 @@
     <link rel="stylesheet" type="text/css" href="style.css">
   </head>
   <body>
-    <iframe src="http://listen.tidal.com" plugins></iframe>
-
+    <webview src="http://listen.tidal.com" preload="./preload.js" plugins></webview>
     <script>
-
-      setInterval(function() {
-        var doc = document.querySelector("iframe").contentDocument
-        if (doc) {
-          var title = doc.title
-          document.title = title
-        }
-      }, 500)
-
-      const ipcRenderer = require('electron').ipcRenderer;
-      ipcRenderer.on('playback-control', function(event, arg) {
-        var doc = document.querySelector("iframe").contentDocument
-
-        switch (arg) {
-          case "MediaPlayPause":
-            var playBtn = doc.querySelector("button.js-play")
-            var pauseBtn = doc.querySelector("button.js-pause")
-            var playPauseContainer= doc.querySelector(".play-controls__main-button")
-            if (playPauseContainer.className.indexOf("playing") == -1) {
-              playBtn.click()
-            }
-            else
-            {
-              pauseBtn.click()
-            }
-            break;
-
-          case "MediaNextTrack":
-            doc.querySelector("button.js-next").click();
-            break;
-
-          case "MediaPreviousTrack":
-            doc.querySelector("button.js-previous").click();
-            break;
-
-          case "MediaStop":
-            doc.querySelector("button.js-pause").click();
-            break;
-        }
+      const ipcRenderer = require("electron").ipcRenderer;
+      ipcRenderer.on("playback-control", function(ev, arg) {
+        // redirect to webview since main ipc can't directly communicate with it
+        document.querySelector("webview").send("playback-control", arg);
       });
-
     </script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -3,26 +3,17 @@
   "version": "1.0.0",
   "description": "An electron wrapped client for Tidal",
   "main": "main.js",
-  "scripts": {
-    "start": "electron main.js"
-  },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/atom/electron-quick-start.git"
+    "url": "git+https://github.com/Bunkerbewohner/tidal-music-linux.git"
   },
-  "keywords": [
-    "Electron",
-    "quick",
-    "start",
-    "tutorial"
-  ],
-  "author": "GitHub",
+  "author": "Bunkerbewohner",
   "license": "CC0-1.0",
   "bugs": {
-    "url": "https://github.com/atom/electron-quick-start/issues"
+    "url": "https://github.com/Bunkerbewohner/tidal-music-linux/issues"
   },
-  "homepage": "https://github.com/atom/electron-quick-start#readme",
-  "devDependencies": {
-    "electron": "^1.0"
+  "homepage": "https://github.com/Bunkerbewohner/tidal-music-linux",
+  "dependencies": {
+    "dbus-native": "^0.2.5"
   }
 }

--- a/preload.js
+++ b/preload.js
@@ -1,0 +1,33 @@
+const ipc = require('electron').ipcRenderer;
+setInterval(function() {
+  // required since webviews can't access the renderer itself
+  ipc.send("title", document.title); // send update request to renderer
+}, 500)
+
+ipc.on('playback-control', (event, arg) => {
+  var doc = document;
+
+  switch (arg) {
+    case "Play":
+      var playBtn = doc.querySelector("button.js-play")
+      var pauseBtn = doc.querySelector("button.js-pause")
+      var playPauseContainer= doc.querySelector(".play-controls__main-button")
+      if (playPauseContainer.className.indexOf("playing") == -1)
+        playBtn.click()
+      else
+        pauseBtn.click()
+      break;
+
+    case "Next":
+      doc.querySelector("button.js-next").click();
+      break;
+
+    case "Previous":
+      doc.querySelector("button.js-previous").click();
+      break;
+
+    case "Stop":
+      doc.querySelector("button.js-pause").click();
+      break;
+  }
+});

--- a/style.css
+++ b/style.css
@@ -11,7 +11,7 @@ body {
   overflow: hidden;
 }
 
-iframe {
+webview {
   width: 100%;
   height: 100%;
   border: 0;


### PR DESCRIPTION
As pointed out on #3, media keys aren't working. It's possible that different electron versions handle iframes differently (maybe the ones with no `webview` tag?), as mine directly redirects to TIDAL web player, leaving no playback control script. From Electron webview docs:

> Use the `webview` tag to embed 'guest' content (such as web pages) in your Electron app. The guest content is contained within the `webview` container. An embedded page within your app controls how the guest content is laid out and rendered. Unlike an `iframe`, the `webview` runs in a separate process than your app.

Now using DBus instead of `globalShortcut` module since there's an issue that prevents the media keys to be handled more than once. (though it **only works on GNOME**)
Also since author says it works for him I suppose different setups handle keys differently. I replaced boilerplate `package.json` infos too, though I know it's not part of this pull request context.