### PR TITLE
Find pepper flash lib dynamically instead of hardcoding it

### DIFF
--- a/main.js
+++ b/main.js
@@ -10,7 +10,7 @@ var globalShortcut = electron.globalShortcut;
 // be closed automatically when the JavaScript object is garbage collected.
 var mainWindow = null;
 
-const pepperFlashPluginPath = find.fileSync('libpepflashplayer.so','/lib')
+const pepperFlashPluginPath = find.fileSync('libpepflashplayer.so','/usr/lib')
 app.commandLine.appendSwitch('ppapi-flash-path', pepperFlashPluginPath);
 
 // Quit when all windows are closed.

--- a/main.js
+++ b/main.js
@@ -1,6 +1,7 @@
 var electron = require('electron');
 var dbus = require('dbus-native');
 var sessionBus = dbus.sessionBus();
+const find = require('find')
 var app = electron.app;  // Module to control application life.
 var BrowserWindow = electron.BrowserWindow;  // Module to create native browser window.
 var globalShortcut = electron.globalShortcut;
@@ -9,8 +10,7 @@ var globalShortcut = electron.globalShortcut;
 // be closed automatically when the JavaScript object is garbage collected.
 var mainWindow = null;
 
-// TODO: Determine path to Pepper flash plugin, rather than hardcoding it
-var pepperFlashPluginPath = '/usr/lib/adobe-flashplugin/libpepflashplayer.so'
+const pepperFlashPluginPath = find.fileSync('libpepflashplayer.so','/lib')
 app.commandLine.appendSwitch('ppapi-flash-path', pepperFlashPluginPath);
 
 // Quit when all windows are closed.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "homepage": "https://github.com/Bunkerbewohner/tidal-music-linux",
   "dependencies": {
     "dbus-native": "^0.2.5",
-    "electron": "^3.0.4"
+    "electron": "^3.0.4",
+    "find": "^0.3.0"
   }
 }


### PR DESCRIPTION
Addresses the `TODO` comment already present in `main.js`. My `libpepflashplayer.so` is not at the hardcoded location and this fixes it