### PR TITLE
Use flash-player-loader to find pepper flash

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,17 +1,19 @@
 var electron = require('electron');
 var dbus = require('dbus-native');
 var sessionBus = dbus.sessionBus();
-const find = require('find')
 var app = electron.app;  // Module to control application life.
 var BrowserWindow = electron.BrowserWindow;  // Module to create native browser window.
 var globalShortcut = electron.globalShortcut;
+const flashLoader = require('flash-player-loader');
+
+for(const path of require('./pepper-paths.json')) {
+  flashLoader.addSource(path);
+}
+flashLoader.load();
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
 var mainWindow = null;
-
-const pepperFlashPluginPath = find.fileSync('libpepflashplayer.so','/usr/lib')
-app.commandLine.appendSwitch('ppapi-flash-path', pepperFlashPluginPath);
 
 // Quit when all windows are closed.
 app.on('window-all-closed', function() {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
   "dependencies": {
     "dbus-native": "^0.2.5",
     "electron": "^3.0.4",
-    "find": "^0.3.0"
+    "flash-player-loader": "^1.2.0"
   }
 }

--- a/pepper-paths.json
+++ b/pepper-paths.json
@@ -1,4 +1,4 @@
 [
-  "/usr/lib/PepperFlash/",
+  "/usr/lib/PepperFlash",
   "/usr/lib/adobe-flashplugin"
 ]

--- a/pepper-paths.json
+++ b/pepper-paths.json
@@ -1,0 +1,4 @@
+[
+  "/usr/lib/PepperFlash/",
+  "/usr/lib/adobe-flashplugin"
+]


### PR DESCRIPTION
After doing some digging on loading pepper-flash, I found a [package](https://github.com/alvin-777/flash-player-loader-for-electron) that is dedicated to loading the player for electron apps. This means no costly brute-force searching at all, given that you supply a list of paths in which `libpep` might be located. In the best case, it also calls `app.getPath("pepperFlashSystemPlugin")` which is the 'correct' way to find the library.

The downside is the search directories need to be hardcoded. I added the original hardcoded directory and the one in which my `libpep` is installed, and the app seems to start up much faster, so I don't think any form of caching/persistent storage is necessary. If other users have different install locations for their `libpep` they can easily be added to `pepper-paths.json`.

I hope this is a better / satisfactory solution! Please review!