### PR TITLE
Electron builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+dist
 node_modules

--- a/README.md
+++ b/README.md
@@ -29,7 +29,40 @@ $ cd tidal-music-linux
 $ npm install && npm start
 ```
 
+## Build to native
 
+This app can be built to a platform-native package for all major Linux distros
+using [electron-builder](https://github.com/electron-userland/electron-builder).
+Simply run `npm run dist:<package format>`.
+
+For instance, for Debian/Ubuntu, run
+
+```sh
+$ npm run dist:deb
+```
+
+And install with:
+
+```sh
+$ dpkg -i dist/your-binary.deb
+```
+
+Or for Arch Linux:
+
+Build:
+
+```sh
+$ npm run dist:pacman
+```
+
+And install:
+
+```
+$ pacman -U dist/your-binary.pacman
+```
+
+For a complete list of electron-builder output formats, check out
+[electron-builder](https://github.com/electron-userland/electron-builder).
 
 #### License [MIT](LICENSE)
 

--- a/package.json
+++ b/package.json
@@ -4,21 +4,40 @@
   "description": "An electron wrapped client for Tidal",
   "main": "main.js",
   "scripts": {
-    "start": "electron main.js"
+    "start": "electron main.js",
+    "pack": "electron-builder --dir",
+    "dist": "electron-builder --linux",
+    "dist:pacman"  : "electron-builder --linux pacman",
+    "dist:AppImage": "electron-builder --linux AppImage",
+    "dist:snap"    : "electron-builder --linux snap",
+    "dist:rpm"     : "electron-builder --linux rpm",
+    "dist:freebsd" : "electron-builder --linux freebsd",
+    "dist:p5p"     : "electron-builder --linux p5p",
+    "dist:deb"     : "electron-builder --linux deb",
+    "dist:apk"     : "electron-builder --linux apk"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Bunkerbewohner/tidal-music-linux.git"
   },
-  "author": "Bunkerbewohner",
+  "author": {
+    "name": "Bunkerbewohner",
+    "email": "bunkerbewohner@dummy"
+  },
   "license": "CC0-1.0",
   "bugs": {
     "url": "https://github.com/Bunkerbewohner/tidal-music-linux/issues"
   },
+  "build": {
+    "appId": "io.github.bunkerbewohner.tidal"
+  },
   "homepage": "https://github.com/Bunkerbewohner/tidal-music-linux",
   "dependencies": {
     "dbus-native": "^0.2.5",
-    "electron": "^3.0.4",
     "find": "^0.3.0"
+  },
+  "devDependencies": {
+    "electron": "^3.0.4",
+    "electron-builder": "^20.39.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,11 @@
     "type": "git",
     "url": "git+https://github.com/Bunkerbewohner/tidal-music-linux.git"
   },
-  "author": {
+  "author": "Mathias Kahl <mathias.kahl@gmail.com>",
+  "contributors": [
+    "Mathias Kahl <mathias.kahl@gmail.com>",
+    "Andrew Lee <andrewl@mbda.fun>"
+  ]
     "name": "Bunkerbewohner",
     "email": "bunkerbewohner@dummy"
   },


### PR DESCRIPTION
I added the configuration necessary to build this project into a native package various linux distros, via electron-builder. I also added an explanation of how to build it in the `README`.

As part of the configuration, an email was required. I didn't know yours, so I added a dummy email. If you have a public email, it would be awesome if you could change that field to that.

Thanks!